### PR TITLE
add indel parsing feature + creating 2 dataframes 1 SNV + 1 indel

### DIFF
--- a/scripts/ingest_snv.py
+++ b/scripts/ingest_snv.py
@@ -28,21 +28,26 @@ def main():
         sys.exit("[ERROR] Do not recognize type of input vcf " + args.vcf + ". Exiting.")
 
     # Input file type is VCF. Start parsing.
-    variants, nr_of_vars, nr_filtered = parse_snv.parse(vcf_reader, args.samplename)
+    variants_snv, variants_indel, nr_of_vars, nr_filtered = parse_snv.parse(vcf_reader, args.samplename)
 
     # Create dataframe from all variant data
-    if variants:
+    if variants_snv or variants_indel:
         columns = ["chrom", "pos", "ref", "alt"]
-        data = pd.DataFrame(variants, columns=columns)
-        print(data)
+        data_snv = pd.DataFrame(variants_snv, columns=columns)
+        data_indel = pd.DataFrame(variants_indel, columns=columns)
+        print("\n[INFO] Dataframe for SNV variants")
+        print(data_snv)
+        print("\n[INFO] Dataframe for indel variants")
+        print(data_indel)
     else:
         sys.exit("No data parsed, please check your input data.")
 
     # Save dataframe to file
     if args.outputfile:
-        data.to_csv(args.outputfile)
-
-    print("Total number of variants processed: " + str(nr_of_vars))
+        data_snv.to_csv(args.outputfile + "_snv.csv")
+        data_indel.to_csv(args.outputfile + "_indel.csv")
+    #print("\n")
+    print("\nTotal number of variants processed: " + str(nr_of_vars))
     print("Filtered variants of total: " + str(nr_filtered))
 
 if __name__ == "__main__":

--- a/scripts/parse_snv.py
+++ b/scripts/parse_snv.py
@@ -6,12 +6,14 @@ def parse(vcf_reader, samplename):
     require the vcf path and the samplename if multisample vcf
     """
 
-    variants = []
+    variants_snv = []
+    variants_indel = []
     sample = None
     nr_of_vars = 0
     nr_filtered = 0
 
     for record in vcf_reader:
+        #print(record.var_type)
         nr_of_vars += 1
 
         # Only use 'PASS' calls
@@ -37,7 +39,17 @@ def parse(vcf_reader, samplename):
             ref = record.REF
             alt = record.ALT
 
-            variants.append([chrom, pos, ref, alt])
+            if record.var_type == "indel":
+                variants_indel.append([chrom, pos, ref, alt])
+                #print("indel: {} {} {}".format(pos,ref,alt))
+
+            elif record.var_type == "snp":
+                #print ("snp: {} {} {}".format(pos,ref,alt))
+                variants_snv.append([chrom, pos, ref, alt])
+            else:
+                print("unknown: {} {} {} {}".format(record.var_type,pos,ref,alt))
+
+
 
         elif record.FILTER != []:
             nr_filtered += 1
@@ -45,4 +57,4 @@ def parse(vcf_reader, samplename):
 
     #print(variants)
 
-    return(variants, nr_of_vars, nr_filtered)
+    return(variants_snv, variants_indel, nr_of_vars, nr_filtered)


### PR DESCRIPTION
Ingest_snv.py can now take vcf files containing snvs and/or indels and will parse those to produce 2 dataframes and 2 .csv files (one for each type of variant)